### PR TITLE
Tentative HorseItem to MountItem fix

### DIFF
--- a/common/src/main/java/com/wynnventory/model/item/simple/SimpleItem.java
+++ b/common/src/main/java/com/wynnventory/model/item/simple/SimpleItem.java
@@ -37,7 +37,7 @@ import net.minecraft.world.item.ItemStack;
     @JsonSubTypes.Type(value = SimpleTierItem.class, name = "MaterialItem"),
     @JsonSubTypes.Type(value = SimpleTierItem.class, name = "PowderItem"),
     @JsonSubTypes.Type(value = SimpleTierItem.class, name = "AmplifierItem"),
-    @JsonSubTypes.Type(value = SimpleTierItem.class, name = "HorseItem"),
+    @JsonSubTypes.Type(value = SimpleTierItem.class, name = "MountItem"),
     @JsonSubTypes.Type(value = SimpleTierItem.class, name = "EmeraldPouchItem")
 })
 public class SimpleItem extends TimestampedObject {

--- a/common/src/main/java/com/wynnventory/model/item/simple/SimpleItemType.java
+++ b/common/src/main/java/com/wynnventory/model/item/simple/SimpleItemType.java
@@ -15,7 +15,7 @@ public enum SimpleItemType {
     MATERIAL("MaterialItem", true),
     POWDER("PowderItem", true),
     AMPLIFIER("AmplifierItem", true),
-    HORSE("HorseItem", true),
+    MOUNT("MountItem", true),
     EMERALD_POUCH("EmeraldPouchItem", true),
 
     // SimpleGearItems

--- a/common/src/main/java/com/wynnventory/model/item/simple/SimpleTierItem.java
+++ b/common/src/main/java/com/wynnventory/model/item/simple/SimpleTierItem.java
@@ -5,9 +5,9 @@ import com.wynntils.models.items.WynnItem;
 import com.wynntils.models.items.WynnItemData;
 import com.wynntils.models.items.items.game.AmplifierItem;
 import com.wynntils.models.items.items.game.EmeraldPouchItem;
-import com.wynntils.models.items.items.game.HorseItem;
 import com.wynntils.models.items.items.game.IngredientItem;
 import com.wynntils.models.items.items.game.MaterialItem;
+import com.wynntils.models.items.items.game.MountItem;
 import com.wynntils.models.items.items.game.PowderItem;
 import com.wynnventory.api.service.IconService;
 import com.wynnventory.model.item.Icon;
@@ -64,7 +64,7 @@ public class SimpleTierItem extends SimpleItem {
             case MaterialItem materialItem -> fromMaterialItem(materialItem);
             case PowderItem powderItem -> fromPowderItem(powderItem);
             case AmplifierItem amplifierItem -> fromAmplifierItem(amplifierItem);
-            case HorseItem horseItem -> fromHorseItem(horseItem);
+            case MountItem mountItem -> fromMountItem(mountItem);
             case EmeraldPouchItem emeraldPouchItem -> fromEmeraldPouchItem(emeraldPouchItem);
             case null, default -> null;
         };
@@ -110,13 +110,9 @@ public class SimpleTierItem extends SimpleItem {
                 amplifierItem.getTier());
     }
 
-    private static SimpleTierItem fromHorseItem(HorseItem horseItem) {
+    private static SimpleTierItem fromMountItem(MountItem mountItem) {
         return createTierItem(
-                horseItem,
-                ItemStackUtils.getHorseName(horseItem),
-                GearTier.NORMAL,
-                SimpleItemType.HORSE,
-                horseItem.getTier().getNumeral());
+                mountItem, ItemStackUtils.getHorseName(mountItem), GearTier.NORMAL, SimpleItemType.MOUNT, 1);
     }
 
     private static SimpleTierItem fromEmeraldPouchItem(EmeraldPouchItem emeraldPouchItem) {

--- a/common/src/main/java/com/wynnventory/util/ItemStackUtils.java
+++ b/common/src/main/java/com/wynnventory/util/ItemStackUtils.java
@@ -11,10 +11,10 @@ import com.wynntils.models.items.items.game.DungeonKeyItem;
 import com.wynntils.models.items.items.game.EmeraldItem;
 import com.wynntils.models.items.items.game.EmeraldPouchItem;
 import com.wynntils.models.items.items.game.GearItem;
-import com.wynntils.models.items.items.game.HorseItem;
 import com.wynntils.models.items.items.game.IngredientItem;
 import com.wynntils.models.items.items.game.InsulatorItem;
 import com.wynntils.models.items.items.game.MaterialItem;
+import com.wynntils.models.items.items.game.MountItem;
 import com.wynntils.models.items.items.game.PowderItem;
 import com.wynntils.models.items.items.game.RuneItem;
 import com.wynntils.models.items.items.game.SimulatorItem;
@@ -53,7 +53,7 @@ public class ItemStackUtils {
             case EmeraldItem emeraldItem -> SimpleItem.from(emeraldItem);
             case EmeraldPouchItem emeraldPouchItem -> SimpleTierItem.from(emeraldPouchItem);
             case GearItem gearItem -> SimpleGearItem.from(gearItem);
-            case HorseItem horseItem -> SimpleTierItem.from(horseItem);
+            case MountItem mountItem -> SimpleTierItem.from(mountItem);
             case IngredientItem ingredientItem -> SimpleTierItem.from(ingredientItem);
             case InsulatorItem insulatorItem -> SimpleItem.from(insulatorItem);
             case MaterialItem materialItem -> SimpleTierItem.from(materialItem);
@@ -135,8 +135,8 @@ public class ItemStackUtils {
         return name;
     }
 
-    public static String getHorseName(HorseItem item) {
-        return StringUtils.toCamelCase(item.getTier().name()) + " Horse";
+    public static String getHorseName(MountItem item) {
+        return StringUtils.toCamelCase(item.getName().orElse(""));
     }
 
     public static ChatFormatting getRarityChatFormattingByName(String rarity) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ fabric_loader_version = 0.18.4
 fabric_api_version = 0.141.3+1.21.11
 neoforge_loader_version = 21.11.38-beta
 neoforge_eventbus_version = 8.0.5
-wynntils_version = 4.1.0-beta.2
+wynntils_version = 4.1.0
 jackson_version = 2.20.1
 
 # Fabric Dependencies


### PR DESCRIPTION
This simply renames all occurrences of HorseItem to MountItem and hard codes the tier 1 to so that TM doesn't crash.

As you can see I opened the TM and didn't crash, even managed to hover over a mount and other items
<img width="2560" height="1417" alt="image" src="https://github.com/user-attachments/assets/82162ec2-ae2e-4b49-92c8-52659ca7c12e" />
