### PR TITLE
fix: crash on reward and raid screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ replay_*.log
 fabric/src/main/resources/key.dat
 neoforge/src/main/resources/key.dat
 /.architectury-transformer
+/.junie

--- a/common/src/main/java/com/wynnventory/gui/widget/ItemButton.java
+++ b/common/src/main/java/com/wynnventory/gui/widget/ItemButton.java
@@ -53,7 +53,8 @@ public class ItemButton<T extends GuideItemStack> extends WynnventoryButton {
         if (color != CustomColor.NONE) {
             float hlSize = 2f * width;
             float hlOffset = width / 2f;
-            RenderUtils.drawSprite(g, Texture.HIGHLIGHT_WYNN, color, getX() - hlOffset, getY() - hlOffset, hlSize, hlSize);
+            RenderUtils.drawSprite(
+                    g, Texture.HIGHLIGHT_WYNN, color, getX() - hlOffset, getY() - hlOffset, hlSize, hlSize);
         }
 
         // Draw item (MC item icon anchored at button origin, scaled)

--- a/common/src/main/java/com/wynnventory/gui/widget/ItemButton.java
+++ b/common/src/main/java/com/wynnventory/gui/widget/ItemButton.java
@@ -51,20 +51,9 @@ public class ItemButton<T extends GuideItemStack> extends WynnventoryButton {
         // Colored highlight like Wynntils (scaled to our box)
         CustomColor color = getCustomColor();
         if (color != CustomColor.NONE) {
-            RenderUtils.drawTexturedRect(
-                    g,
-                    Texture.HIGHLIGHT.identifier(),
-                    color,
-                    getX() - 1f,
-                    getY() - 1f,
-                    width + 2f,
-                    height + 2f,
-                    0,
-                    0,
-                    18,
-                    18,
-                    Texture.HIGHLIGHT.width(),
-                    Texture.HIGHLIGHT.height());
+            float hlSize = 2f * width;
+            float hlOffset = width / 2f;
+            RenderUtils.drawSprite(g, Texture.HIGHLIGHT_WYNN, color, getX() - hlOffset, getY() - hlOffset, hlSize, hlSize);
         }
 
         // Draw item (MC item icon anchored at button origin, scaled)

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ fabric_loader_version = 0.18.4
 fabric_api_version = 0.141.3+1.21.11
 neoforge_loader_version = 21.11.38-beta
 neoforge_eventbus_version = 8.0.5
-wynntils_version = 4.1.6
+wynntils_version = 4.1.17
 jackson_version = 2.20.1
 
 # Fabric Dependencies


### PR DESCRIPTION
wynntils 4.1.17 changed Texture.HIGHLIGHT to Texture.HIGHLIGHT_WYNN as a sprite
breaking wynntils commit: https://github.com/Wynntils/Wynntils/commit/ba92fae60f4806dac8b9b27458b4377df1db1510
please merge this into the price-predictions branch as well

fixes #232 