### PR TITLE
fix: Fix getting material item name

### DIFF
--- a/common/src/main/java/com/wynnventory/model/item/simple/SimpleTierItem.java
+++ b/common/src/main/java/com/wynnventory/model/item/simple/SimpleTierItem.java
@@ -83,7 +83,7 @@ public class SimpleTierItem extends SimpleItem {
     private static SimpleTierItem fromMaterialItem(MaterialItem materialItem) {
         return createTierItem(
                 materialItem,
-                ItemStackUtils.getMaterialName(materialItem),
+                materialItem.getMaterialInfo().name(),
                 GearTier.NORMAL,
                 SimpleItemType.MATERIAL,
                 materialItem.getProfessionTypes().toString(),

--- a/common/src/main/java/com/wynnventory/util/ItemStackUtils.java
+++ b/common/src/main/java/com/wynnventory/util/ItemStackUtils.java
@@ -95,12 +95,6 @@ public class ItemStackUtils {
         return Component.literal(cleanName).withStyle(style);
     }
 
-    public static String getMaterialName(MaterialItem item) {
-        String source = item.getMaterialProfile().getSourceMaterial().name();
-        String resource = item.getMaterialProfile().getResourceType().name();
-        return StringUtils.toCamelCase(source + " " + resource, " ");
-    }
-
     public static String getPowderName(PowderItem item) {
         return item.getPowderProfile().element().getName() + " Powder";
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ fabric_loader_version = 0.18.4
 fabric_api_version = 0.141.3+1.21.11
 neoforge_loader_version = 21.11.38-beta
 neoforge_eventbus_version = 8.0.5
-wynntils_version = 4.1.17
+wynntils_version = 4.2.1
 jackson_version = 2.20.1
 
 # Fabric Dependencies


### PR DESCRIPTION
I removed all the hardcoded material data and now it's parsed from the API, so the name is now present, it's the key in https://cdn.wynntils.com/static/Reference/materials_expanded.json